### PR TITLE
Avoid importing Gtk unnecessarily

### DIFF
--- a/gbulb/glib_events.py
+++ b/gbulb/glib_events.py
@@ -7,8 +7,6 @@ from asyncio import events, tasks, unix_events
 
 from gi.repository import GLib, Gio
 
-from .utils import gtk_available
-
 __all__ = ['GLibEventLoop', 'GLibEventLoopPolicy']
 
 
@@ -373,67 +371,3 @@ class GLibEventLoopPolicy(events.AbstractEventLoopPolicy):
             context=GLib.main_context_default(), application=self._application)
         l._policy = self
         return l
-
-
-if gtk_available():
-    __all__.extend(['GtkEventLoop', 'GtkEventLoopPolicy'])
-
-    from gi.repository import Gtk
-
-    class GtkEventLoop(GLibEventLoop):
-        """Gtk-based event loop.
-
-        This loop supports recursion in Gtk, for example for implementing modal
-        windows.
-        """
-        def __init__(self, **kwargs):
-            self._recursive = 0
-            self._recurselock = threading.Lock()
-            kwargs['context'] = GLib.main_context_default()
-
-            super().__init__(**kwargs)
-
-        def run(self):
-            """Run the event loop until Gtk.main_quit is called.
-
-            May be called multiple times to recursively start it again. This
-            is useful for implementing asynchronous-like dialogs in code that
-            is otherwise not asynchronous, for example modal dialogs.
-            """
-            if self.is_running():
-                with self._recurselock:
-                    self._recursive += 1
-                try:
-                    Gtk.main()
-                finally:
-                    with self._recurselock:
-                        self._recursive -= 1
-            else:
-                super().run()
-
-        def stop(self):
-            """Stop the inner-most event loop.
-
-            If it's also the outer-most event loop, the event loop will stop.
-            """
-            with self._recurselock:
-                r = self._recursive
-            if r > 0:
-                Gtk.main_quit()
-            else:
-                super().stop()
-
-    class GtkEventLoopPolicy(GLibEventLoopPolicy):
-        """Gtk-based event loop policy. Use this if you are using Gtk."""
-        def _new_default_loop(self):
-            l = GtkEventLoop(application=self._application)
-            l._policy = self
-            return l
-
-        def new_event_loop(self):
-            if not self._default_loop:
-                l = self.get_default_loop()
-            else:
-                l = GtkEventLoop()
-            l._policy = self
-            return l

--- a/gbulb/gtk.py
+++ b/gbulb/gtk.py
@@ -1,0 +1,66 @@
+import threading
+
+from gi.repository import GLib, Gtk
+
+from .glib_events import GLibEventLoop, GLibEventLoopPolicy
+
+__all__ = ['GtkEventLoop', 'GtkEventLoopPolicy']
+
+
+class GtkEventLoop(GLibEventLoop):
+    """Gtk-based event loop.
+
+    This loop supports recursion in Gtk, for example for implementing modal
+    windows.
+    """
+    def __init__(self, **kwargs):
+        self._recursive = 0
+        self._recurselock = threading.Lock()
+        kwargs['context'] = GLib.main_context_default()
+
+        super().__init__(**kwargs)
+
+    def run(self):
+        """Run the event loop until Gtk.main_quit is called.
+
+        May be called multiple times to recursively start it again. This
+        is useful for implementing asynchronous-like dialogs in code that
+        is otherwise not asynchronous, for example modal dialogs.
+        """
+        if self.is_running():
+            with self._recurselock:
+                self._recursive += 1
+            try:
+                Gtk.main()
+            finally:
+                with self._recurselock:
+                    self._recursive -= 1
+        else:
+            super().run()
+
+    def stop(self):
+        """Stop the inner-most event loop.
+
+        If it's also the outer-most event loop, the event loop will stop.
+        """
+        with self._recurselock:
+            r = self._recursive
+        if r > 0:
+            Gtk.main_quit()
+        else:
+            super().stop()
+
+class GtkEventLoopPolicy(GLibEventLoopPolicy):
+    """Gtk-based event loop policy. Use this if you are using Gtk."""
+    def _new_default_loop(self):
+        l = GtkEventLoop(application=self._application)
+        l._policy = self
+        return l
+
+    def new_event_loop(self):
+        if not self._default_loop:
+            l = self.get_default_loop()
+        else:
+            l = GtkEventLoop()
+        l._policy = self
+        return l

--- a/gbulb/utils.py
+++ b/gbulb/utils.py
@@ -3,20 +3,6 @@ import weakref
 
 __all__ = ['install', 'get_event_loop', 'wait_signal']
 
-_gtk_available = None
-
-
-def gtk_available():  #pragma: no cover
-    global _gtk_available
-    if _gtk_available is None:
-        try:
-            from gi.repository import Gtk
-        except ImportError:
-            Gtk = None
-
-        _gtk_available = bool(Gtk)
-    return _gtk_available
-
 
 def install(gtk=False):
     """Set the default event loop policy.
@@ -30,11 +16,8 @@ def install(gtk=False):
     """
 
     if gtk:
-        if not gtk_available():
-            raise ValueError("Gtk is not available")
-        else:
-            from .glib_events import GtkEventLoopPolicy
-            policy = GtkEventLoopPolicy()
+        from .gtk import GtkEventLoopPolicy
+        policy = GtkEventLoopPolicy()
     else:
         from .glib_events import GLibEventLoopPolicy
         policy = GLibEventLoopPolicy()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 
 setup(name='gbulb',
-      version='0.1',
+      version='0.2',
       description='GLib event loop for tulip (PEP 3156)',
       author='Anthony Baire',
       author_email='ayba@free.fr',

--- a/tests/test_glib_events.py
+++ b/tests/test_glib_events.py
@@ -13,7 +13,7 @@ except ImportError:  # pragma: no cover
 
 @pytest.fixture
 def gtk_policy():
-    from gbulb.glib_events import GtkEventLoopPolicy
+    from gbulb.gtk import GtkEventLoopPolicy
     return GtkEventLoopPolicy()
 
 
@@ -48,7 +48,7 @@ class TestGLibEventLoopPolicy:
 @pytest.mark.skipif(not Gtk, reason="Gtk is not available")
 class TestGtkEventLoopPolicy:
     def test_new_event_loop(self, gtk_policy):
-        from gbulb.glib_events import GtkEventLoop
+        from gbulb.gtk import GtkEventLoop
         a = gtk_policy.new_event_loop()
         b = gtk_policy.new_event_loop()
 


### PR DESCRIPTION
Nobody wants to import Gtk in non-GUI programs just to check it's there.

Move Gtk-dependent classes into a separate module and put the user in control. Don't play games with Gtk availability at all. Don't hide whatever exception Gtk import might throw.

Bump version to 0.2 due to API changes.