### PR TITLE
Follow-up to Gtk-related changes

### DIFF
--- a/examples/test-gtk.py
+++ b/examples/test-gtk.py
@@ -2,6 +2,7 @@
 from gi.repository import Gtk
 import asyncio
 import gbulb
+import gbulb.gtk
 
 
 class ProgressBarWindow(Gtk.Window):
@@ -63,10 +64,11 @@ class ProgressBarWindow(Gtk.Window):
             self._running.cancel()
 
 
-asyncio.set_event_loop_policy(gbulb.GtkEventLoopPolicy())
+asyncio.set_event_loop_policy(gbulb.gtk.GtkEventLoopPolicy())
 
 win = ProgressBarWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("delete-event", lambda *args: loop.stop())
 win.show_all()
 
-asyncio.get_event_loop().run_forever()
+loop = asyncio.get_event_loop()
+loop.run_forever()

--- a/tests/test_gtk.py
+++ b/tests/test_gtk.py
@@ -1,0 +1,51 @@
+import pytest
+
+from utils import gtk_loop, gtk_policy
+
+try:
+    from gi.repository import Gtk
+except ImportError:  # pragma: no cover
+    Gtk = None
+
+
+@pytest.mark.skipif(not Gtk, reason="Gtk is not available")
+class TestGtkEventLoopPolicy:
+    def test_new_event_loop(self, gtk_policy):
+        from gbulb.gtk import GtkEventLoop
+        a = gtk_policy.new_event_loop()
+        b = gtk_policy.new_event_loop()
+
+        assert isinstance(a, GtkEventLoop)
+        assert isinstance(b, GtkEventLoop)
+        assert a != b
+        assert a == gtk_policy.get_default_loop()
+
+    def test_new_event_loop_application(self, gtk_policy):
+        a = gtk_policy.new_event_loop()
+        a.set_application(Gtk.Application())
+        b = gtk_policy.new_event_loop()
+
+        assert b._application is None
+
+    def test_event_loop_recursion(self, gtk_loop):
+        loop_count = 0
+
+        def inner():
+            nonlocal loop_count
+            i = loop_count
+            print('starting loop', loop_count)
+            loop_count += 1
+
+            if loop_count == 10:
+                print('loop {} stopped'.format(i))
+                gtk_loop.stop()
+            else:
+                gtk_loop.call_soon(inner)
+                gtk_loop.run()
+                print('loop {} stopped'.format(i))
+                gtk_loop.stop()
+
+        gtk_loop.call_soon(inner)
+        gtk_loop.run_forever()
+
+        assert loop_count == 10

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ from utils import glib_loop
     (True, True),
 ])
 def test_install(gtk, gtk_available):
-    import gbulb
+    from gbulb import install
     import sys
 
     called = False
@@ -37,7 +37,7 @@ def test_install(gtk, gtk_available):
         with mock.patch('asyncio.set_event_loop_policy', set_event_loop_policy):
             import_error = gtk and not gtk_available
             try:
-                gbulb.install(gtk=gtk)
+                install(gtk=gtk)
             except ImportError:
                 assert import_error
             else:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,13 +21,25 @@ def glib_policy():
     return GLibEventLoopPolicy()
 
 
+@pytest.fixture
+def gtk_policy():
+    from gbulb.gtk import GtkEventLoopPolicy
+    return GtkEventLoopPolicy()
+
+
 @pytest.yield_fixture(scope='function')
 def glib_loop():
     l = glib_policy().new_event_loop()
     setup_test_loop(l)
-
     yield l
-
     check_loop_failures(l)
+    l.close()
 
+
+@pytest.yield_fixture(scope='function')
+def gtk_loop():
+    l = gtk_policy().new_event_loop()
+    setup_test_loop(l)
+    yield l
+    check_loop_failures(l)
     l.close()


### PR DESCRIPTION
Some missing bits and organizing of gtk tests.

Also:
- `gtk_policy` and `gtk_loop` fixtures are moved to tests/utils.py to live close to their glib counterparts
- `gtk_loop` is changed a bit to follow the way `glib_loop` was written - please check if that's OK as my pytest-fu is quite weak.