### PR TITLE
Fix race condition during Handle creation.

### DIFF
--- a/gbulb/glib_events.py
+++ b/gbulb/glib_events.py
@@ -74,9 +74,9 @@ class GLibHandle(events.Handle):
         self._loop = loop
         self._source = source
         self._repeat = repeat
+        loop._handlers.add(self)
         source.set_callback(self.__callback__, self)
         source.attach(loop._context)
-        loop._handlers.add(self)
 
     def cancel(self):
         super().cancel()


### PR DESCRIPTION
This fixes a race condition leading to a memory leak. The source can be
executed even before the handle was added to the handlers set. In that
case, it is only added after being run and never removed.

Fix this problem by adding it to the handlers set before attaching the
source.