### PR TITLE
Older versions dont have underscore attribute. Now its backwards comp…

### DIFF
--- a/gbulb/glib_events.py
+++ b/gbulb/glib_events.py
@@ -285,7 +285,7 @@ class BaseGLibEventLoop(unix_events.SelectorEventLoop):
 
     # Disgusting backwards compatibility hack to ensure gbulb keeps working
     # with Python versions that don't have http://bugs.python.org/issue28369
-    if not hasattr(unix_events.SelectorEventLoop, 'add_reader'):
+    if not hasattr(unix_events.SelectorEventLoop, '_add_reader'):
         add_reader = _add_reader
         add_writer = _add_writer
         remove_writer = _remove_writer


### PR DESCRIPTION
I tested and checked this on a python version before the bug fix (3.5.2) on Ubuntu and on a python version after (3.5.3rc1) on Debian Stretch.