### PR TITLE
Windows support

### DIFF
--- a/gbulb/glib_events.py
+++ b/gbulb/glib_events.py
@@ -259,7 +259,7 @@ class GLibBaseEventLoop(_BaseEventLoop, GLibBaseEventLoopPlatformExt):
     def _make_datagram_transport(self, sock, protocol,
                                  address=None, waiter=None, extra=None):
         """Create datagram transport."""
-        raise NotImplementedError
+        return transports.DatagramTransport(self, sock, protocol, address, waiter, extra)
 
     def _make_read_pipe_transport(self, pipe, protocol, waiter=None,
                                   extra=None):
@@ -472,9 +472,19 @@ class GLibBaseEventLoop(_BaseEventLoop, GLibBaseEventLoopPlatformExt):
         read_func = lambda channel, nbytes: sock.recv(nbytes, flags)
         return self._channel_read(channel, nbytes, read_func)
 
+    def sock_recvfrom(self, sock, nbytes, flags=0):
+        channel = self._channel_from_socket(sock)
+        read_func = lambda channel, nbytes: sock.recvfrom(nbytes, flags)
+        return self._channel_read(channel, nbytes, read_func)
+
     def sock_sendall(self, sock, buf, flags=0):
         channel = self._channel_from_socket(sock)
         write_func = lambda channel, buf: sock.send(buf, flags)
+        return self._channel_write(channel, buf, write_func)
+
+    def sock_sendallto(self, sock, buf, addr, flags=0):
+        channel = self._channel_from_socket(sock)
+        write_func = lambda channel, buf: sock.sendto(buf, flags, addr)
         return self._channel_write(channel, buf, write_func)
     
     

--- a/gbulb/transports.py
+++ b/gbulb/transports.py
@@ -1,6 +1,7 @@
 import collections
 import socket
-from asyncio import futures, transports
+import subprocess
+from asyncio import base_subprocess, futures, transports
 
 
 
@@ -404,3 +405,10 @@ class PipeWriteTransport(WriteTransport):
             super()._force_close_async(exc)
         finally:
             self._channel.shutdown(True)
+
+
+class SubprocessTransport(base_subprocess.BaseSubprocessTransport):
+    def _start(self, args, shell, stdin, stdout, stderr, bufsize, **kwargs):
+        self._proc = subprocess.Popen(
+            args, shell=shell, stdin=stdin, stdout=stdout, stderr=stderr,
+            bufsize=bufsize, **kwargs)

--- a/gbulb/transports.py
+++ b/gbulb/transports.py
@@ -19,6 +19,9 @@ class BaseTransport(transports.BaseTransport):
         self._closed = False
         self._cancelable = set()
         
+        if sock is not None:
+            self._loop._transports[sock.fileno()] = self
+        
         if self._server is not None:
             self._server._attach()
         

--- a/gbulb/transports.py
+++ b/gbulb/transports.py
@@ -1,0 +1,298 @@
+import socket
+from asyncio import futures, transports
+
+
+
+class BaseTransport(transports.BaseTransport):
+    def __init__(self, loop, sock, protocol, waiter=None, extra=None, server=None):
+        if hasattr(self, '_sock'):
+            return  # The joys of multiple inheritance
+        
+        transports.BaseTransport.__init__(self, extra)
+        
+        self._loop = loop
+        self._sock = sock
+        self._protocol = protocol
+        self._server = server
+        self._closing = False
+        self._closing_delayed = False
+        self._closed = False
+        self._cancelable = set()
+        
+        if self._server is not None:
+            self._server._attach()
+        
+        def transport_async_init():
+            self._protocol.connection_made(self)
+            if waiter is not None and not waiter.cancelled():
+                waiter.set_result(None)
+        self._loop.call_soon(transport_async_init)
+    
+    def close(self):
+        self._closing = True
+        if not self._closing_delayed:
+            self._force_close(None)
+    
+    def is_closing(self):
+        return self._closing
+    
+    def set_protocol(self, protocol):
+        self._protocol = protocol
+    
+    def get_protocol(self):
+        return self._protocol
+    
+    def _fatal_error(self, exc, message='Fatal error on pipe transport'):
+        self._loop.call_exception_handler({
+            'message': message,
+            'exception': exc,
+            'transport': self,
+            'protocol': self._protocol,
+        })
+        self._force_close(exc)
+    
+    def _force_close(self, exc):
+        if self._closed:
+            return
+        self._closed = True
+        
+        # Stop all running tasks
+        for cancelable in self._cancelable:
+            cancelable.cancel()
+        self._cancelable.clear()
+        
+        def transport_async_close(exc):
+            try:
+                self._protocol.connection_lost(exc)
+            finally:
+                self._sock.close()
+                self._sock = None
+                if self._server is not None:
+                    self._server._detach()
+                    self._server = None
+        self._loop.call_soon(transport_async_close, exc)
+        
+
+
+class ReadTransport(BaseTransport, transports.ReadTransport):
+    max_size = 256 * 1024
+    
+    
+    def __init__(self, *args, **kwargs):
+        BaseTransport.__init__(self, *args, **kwargs)
+        
+        self._paused = False
+        self._read_fut = None
+        self._loop.call_soon(self._loop_reading)
+    
+    def pause_reading(self):
+        if self._closing:
+            raise RuntimeError('Cannot pause_reading() when closing')
+        if self._paused:
+            raise RuntimeError('Already paused')
+        self._paused = True
+    
+    def resume_reading(self):
+        if not self._paused:
+            raise RuntimeError('Not paused')
+        self._paused = False
+        if self._closing:
+            return
+        self._loop.call_soon(self._loop_reading, self._read_fut)
+    
+    def _close_read(self):
+        # Separate method to allow `Transport.close()` to call us without
+        # us delegating to `BaseTransport.close()`
+        if self._read_fut is not None:
+            self._read_fut.cancel()
+            self._read_fut = None
+    
+    def close(self):
+        self._close_read()
+        
+        super().close()
+    
+    def _loop_reading(self, fut=None):
+        if self._paused:
+            return
+        data = None
+        
+        try:
+            if fut is not None:
+                assert self._read_fut is fut or (self._read_fut is None and self._closing)
+                if self._read_fut in self._cancelable:
+                    self._cancelable.remove(self._read_fut)
+                self._read_fut = None
+                data = fut.result()  # Deliver data later in "finally" clause
+            
+            if self._closing:
+                # Since `.close()` has been called we ignore any read data
+                data = None
+                return
+            
+            if data == b'':
+                # No need to reschedule on end-of-file
+                return
+            
+            # Reschedule a new read
+            self._read_fut = self._loop.sock_recv(self._sock, self.max_size)
+            self._cancelable.add(self._read_fut)
+        except ConnectionAbortedError as exc:
+            if not self._closing:
+                self._fatal_error(exc, 'Fatal read error on pipe transport')
+        except ConnectionResetError as exc:
+            self._force_close(exc)
+        except OSError as exc:
+            self._fatal_error(exc, 'Fatal read error on pipe transport')
+        except futures.CancelledError:
+            if not self._closing:
+                raise
+        except futures.InvalidStateError:
+            self._read_fut = fut
+            self._cancelable.add(self._read_fut)
+        else:
+            self._read_fut.add_done_callback(self._loop_reading)
+        finally:
+            if data:
+                self._protocol.data_received(data)
+            elif data is not None:
+                keep_open = self._protocol.eof_received()
+                if not keep_open:
+                    self.close()
+
+
+class WriteTransport(BaseTransport, transports._FlowControlMixin):
+    def __init__(self, loop, *args, **kwargs):
+        transports._FlowControlMixin.__init__(self, None, loop)
+        BaseTransport.__init__(self, loop, *args, **kwargs)
+        
+        self._buffer = bytearray()
+        self._buffer_empty_callbacks = set()
+        self._write_fut = None
+    
+    def abort(self):
+        self._force_close(None)
+    
+    def can_write_eof(self):
+        return True
+    
+    def get_write_buffer_size(self):
+        return len(self._buffer)
+    
+    def _close_write(self):
+        if self._write_fut is not None:
+            self._closing_delayed = True
+            
+            def transport_write_done_callback():
+                self._closing_delayed = False
+                self.close()
+            self._buffer_empty_callbacks.add(transport_write_done_callback)
+    
+    def close(self):
+        self._close_write()
+        
+        super().close()
+    
+    def write(self, data):
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise TypeError('data argument must be byte-ish (%r)', type(data))
+        if self._eof_written:
+            raise RuntimeError('write_eof() already called')
+        
+        # Ignore empty data sets or requests to write to a dying connection
+        if not data or self._closing:
+            return
+        
+        if self._write_fut is None:  # No data is currently buffered or being sent
+            self._loop_writing(data=data)
+        else:
+            self._buffer.extend(data)
+            self._maybe_pause_protocol()  # From _FlowControlMixin
+    
+    def _loop_writing(self, fut=None, data=None):
+        try:
+            assert fut is self._write_fut
+            if self._write_fut in self._cancelable:
+                 self._cancelable.remove(self._write_fut)
+            self._write_fut = None
+            
+            # Raise possible exception stored in `fut`
+            if fut:
+                fut.result()
+            
+            # Use buffer as next data object if invoked from done callback
+            if data is None:
+                data = self._buffer
+                self._buffer = bytearray()
+            
+            if not data:
+                if len(self._buffer_empty_callbacks) > 0:
+                    for callback in self._buffer_empty_callbacks:
+                        callback()
+                    self._buffer_empty_callbacks.clear()
+                
+                self._maybe_resume_protocol()
+            else:
+                self._write_fut = self._loop.sock_sendall(self._sock, data)
+                self._cancelable.add(self._write_fut)
+                if not self._write_fut.done():
+                    self._write_fut.add_done_callback(self._loop_writing)
+                    self._maybe_pause_protocol()
+                else:
+                    self._write_fut.add_done_callback(self._loop_writing)
+        except ConnectionResetError as exc:
+            self._force_close(exc)
+        except OSError as exc:
+            self._fatal_error(exc, 'Fatal write error on pipe transport')
+    
+    def write_eof(self):
+        self.close()
+
+
+class Transport(ReadTransport, WriteTransport):
+    def __init__(self, *args, **kwargs):
+        ReadTransport.__init__(self, *args, **kwargs)
+        WriteTransport.__init__(self, *args, **kwargs)
+    
+    
+    def close(self):
+        # Need to invoke both the read's and the write's part of the transport `close` function
+        self._close_read()
+        self._close_write()
+        
+        BaseTransport.close(self)
+
+
+class SocketTransport(Transport):
+    def __init__(self, *args, **kwargs):
+        self._eof_written = False
+        
+        super().__init__(*args, **kwargs)
+        
+        # Set expected extra attributes (available through `.get_extra_info()`)
+        self._extra['socket'] = self._sock
+        try:
+            self._extra['sockname'] = self._sock.getsockname()
+        except (OSError, AttributeError):
+            pass
+        if 'peername' not in self._extra:
+            try:
+                self._extra['peername'] = self._sock.getpeername()
+            except (OSError, AttributeError) as error:
+                pass
+    
+    
+    def write_eof(self):
+        if self._closing or self._eof_written:
+            return
+        self._eof_written = True
+        
+        if self._write_fut is None:
+            self._sock.shutdown(socket.SHUT_WR)
+        else:
+            def transport_write_eof_callback():
+                if not self._closing:
+                    self._sock.shutdown(socket.SHUT_WR)
+            self._buffer_empty_callbacks.add(transport_write_eof_callback)
+
+

--- a/tests/test_glib_events.py
+++ b/tests/test_glib_events.py
@@ -1,11 +1,14 @@
 import asyncio
+import sys
 
 import pytest
 
-from unittest import mock
+from unittest import mock, skipIf
 from gi.repository import Gio
 
 from utils import glib_loop, glib_policy
+
+is_windows = (sys.platform == "win32")
 
 
 class TestGLibEventLoopPolicy:
@@ -71,6 +74,7 @@ def no_op_coro():
 
 
 class TestBaseGLibEventLoop:
+    @skipIf(is_windows, "Unix signal handlers are not supported on Windows")
     def test_add_signal_handler(self, glib_loop):
         import os
         import signal
@@ -90,6 +94,7 @@ class TestBaseGLibEventLoop:
 
         assert called, 'signal handler didnt fire'
 
+    @skipIf(is_windows, "Unix signal handlers are not supported on Windows")
     def test_remove_signal_handler(self, glib_loop):
         import signal
 
@@ -101,15 +106,18 @@ class TestBaseGLibEventLoop:
 
         # FIXME: it'd be great if we could actually try signalling the process
 
+    @skipIf(is_windows, "Unix signal handlers are not supported on Windows")
     def test_remove_signal_handler_unhandled(self, glib_loop):
         import signal
         assert not glib_loop.remove_signal_handler(signal.SIGHUP)
 
+    @skipIf(is_windows, "Unix signal handlers are not supported on Windows")
     def test_remove_signal_handler_sigkill(self, glib_loop):
         import signal
         with pytest.raises(RuntimeError):
             glib_loop.add_signal_handler(signal.SIGKILL, None)
 
+    @skipIf(is_windows, "Unix signal handlers are not supported on Windows")
     def test_remove_signal_handler_sigill(self, glib_loop):
         import signal
         with pytest.raises(ValueError):
@@ -126,6 +134,7 @@ class TestBaseGLibEventLoop:
         with pytest.raises(RuntimeError):
             glib_loop.run_until_complete(coro())
 
+    @skipIf(is_windows, "Waiting on raw file descriptors only works for sockets on Windows")
     def test_add_writer(self, glib_loop):
         import os
         rfd, wfd = os.pipe()
@@ -145,6 +154,7 @@ class TestBaseGLibEventLoop:
 
         assert called, 'callback handler didnt fire'
 
+    @skipIf(is_windows, "Waiting on raw file descriptors only works for sockets on Windows")
     def test_add_reader(self, glib_loop):
         import os
         rfd, wfd = os.pipe()
@@ -164,6 +174,7 @@ class TestBaseGLibEventLoop:
 
         assert called, 'callback handler didnt fire'
 
+    @skipIf(is_windows, "Waiting on raw file descriptors only works for sockets on Windows")
     def test_add_reader_file(self, glib_loop):
         import os
         rfd, wfd = os.pipe()
@@ -175,6 +186,7 @@ class TestBaseGLibEventLoop:
 
         glib_loop.add_reader(f, None)
 
+    @skipIf(is_windows, "Waiting on raw file descriptors only works for sockets on Windows")
     def test_add_writer_file(self, glib_loop):
         import os
         rfd, wfd = os.pipe()
@@ -186,6 +198,7 @@ class TestBaseGLibEventLoop:
 
         glib_loop.add_writer(f, None)
 
+    @skipIf(is_windows, "Waiting on raw file descriptors only works for sockets on Windows")
     def test_remove_reader(self, glib_loop):
         import os
         rfd, wfd = os.pipe()
@@ -200,6 +213,7 @@ class TestBaseGLibEventLoop:
         assert glib_loop.remove_reader(f)
         assert not glib_loop.remove_reader(f.fileno())
 
+    @skipIf(is_windows, "Waiting on raw file descriptors only works for sockets on Windows")
     def test_remove_writer(self, glib_loop):
         import os
         rfd, wfd = os.pipe()
@@ -236,7 +250,7 @@ class TestBaseGLibEventLoop:
 
             print(now, s)
             import math
-            assert math.isclose(now, s, abs_tol=0.1)
+            assert math.isclose(now, s, abs_tol=0.2)
 
         s = glib_loop.time()
 
@@ -272,6 +286,7 @@ class TestBaseGLibEventLoop:
         assert items
         assert items == sorted(items)
 
+    @skipIf(is_windows, "Waiting on raw file descriptors only works for sockets on Windows")
     def test_call_soon_priority(self, glib_loop):
         def remover(fd):
             nonlocal removed
@@ -313,6 +328,7 @@ class TestBaseGLibEventLoop:
             os.close(rfd)
             os.close(wfd)
 
+    @skipIf(is_windows, "Waiting on raw file descriptors only works for sockets on Windows")
     def test_add_writer_multiple_calls(self, glib_loop):
         import os
         rfd, wfd = os.pipe()
@@ -448,6 +464,7 @@ class TestGLibEventLoop:
                 glib_loop.set_application(app)
 
 
+@skipIf(is_windows, "Unix signal handlers are not supported on Windows")
 def test_default_signal_handling(glib_loop):
     import os
     import signal


### PR DESCRIPTION
As can be seen from the list of known issues below, this still needs some work to be really usable, but the initial implementation is done and if you have any feedback or suggestions about it I'd be happy to discuss that with you and incorporate any necessary changes.
As you study the code you'll probably notice that this is a mostly rewrite of the library, implementing a full-fledged event loop (similar to `asyncio`'s `SelectorEventLoop` and `ProactorEventLoop`) on top of `base_events.BaseEventLoop` instead of somehow trying to use `SelectorEventLoop` for this. This IMHO makes for more readable and stable code, because we're simply implementing the well defined interfaces from the `BaseEventLoop` instead of monkey-patching `SelectorEventLoop` to fit our needs.

Known issues:

  - ~TCP connection closings are not received with the standard GLib or GTK event loop on Windows~
  - ~TLS does not work with Python 3.4 and below (even outside of Windows)~
  - ~UDP and Pipe support missing~
  - ~Support for the `add_reader` and `add_writer` APIs is still lacking~
  - ~Unix domain sockets and signals support is also still missing~
  - ~Subprocess support is untested currently~
  - ~Not tested with anything older than Python 3.5.2~

Passes most of the `aiohttp` test suite on Linux (except for 2 tests that I believe to be incorrect after debugging them for a couple of hours), Windows results for the test suite are not quite on par yet, but a standard HTTPS with a large number of requests and many transferred bytes has completed without errors.