### PR TITLE
Fix syntax error for Python 3.5+ by replacing tasks.async

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,9 +1,8 @@
 matrix:
     PYTHON_VERSION:
-        - 3.4.3
-        - 3.4.6
-        - 3.5.3
-        - 3.6.0
+        - 3.5.5
+        - 3.6.6
+        - 3.7.0
 
 pipeline:
     build:

--- a/gbulb/glib_events.py
+++ b/gbulb/glib_events.py
@@ -39,11 +39,6 @@ if sys.platform == "win32":
 else:
     from asyncio.unix_events import AbstractChildWatcher
 
-# Keep compatibility with Python 3.4.0
-try:
-    tasks.ensure_future = tasks.ensure_future
-except AttributeError:
-    tasks.ensure_future = tasks.async
 
 
 class GLibChildWatcher(AbstractChildWatcher):
@@ -731,7 +726,12 @@ class GLibEventLoop(GLibBaseEventLoop):
         def stop(f):
             self.stop()
 
-        future = tasks.ensure_future(future, loop=self)
+        # Keep compatibility with Python 3.4.0
+        try:
+            future = tasks.ensure_future(future, loop=self)
+        except AttributeError:
+            future = tasks.async(future, loop=self)
+
         future.add_done_callback(stop)
         try:
             self.run_forever(**kw)

--- a/gbulb/glib_events.py
+++ b/gbulb/glib_events.py
@@ -725,7 +725,7 @@ class GLibEventLoop(GLibBaseEventLoop):
         def stop(f):
             self.stop()
 
-        future = tasks.async(future, loop=self)
+        future = tasks.ensure_future(future, loop=self)
         future.add_done_callback(stop)
         try:
             self.run_forever(**kw)

--- a/gbulb/glib_events.py
+++ b/gbulb/glib_events.py
@@ -39,6 +39,12 @@ if sys.platform == "win32":
 else:
     from asyncio.unix_events import AbstractChildWatcher
 
+# Keep compatibility with Python 3.4.0
+try:
+    tasks.ensure_future = tasks.ensure_future
+except AttributeError:
+    tasks.ensure_future = tasks.async
+
 
 class GLibChildWatcher(AbstractChildWatcher):
     def __init__(self):

--- a/gbulb/glib_events.py
+++ b/gbulb/glib_events.py
@@ -714,8 +714,10 @@ class GLibEventLoop(GLibBaseEventLoop):
 
         future = tasks.ensure_future(future, loop=self)
         future.add_done_callback(stop)
-        self.run_forever(**kw)
-        future.remove_done_callback(stop)
+        try:
+            self.run_forever(**kw)
+        finally:
+            future.remove_done_callback(stop)
 
         if not future.done():
             raise RuntimeError('Event loop stopped before Future completed.')

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules",
-    ]
+    ],
+    python_requires='>3.5'
 )


### PR DESCRIPTION
This pull request fixes a syntax error when running GBulb in Python 3.5+. The reason the syntax was changed was that asyncio.async had to be replaced with asyncio.ensure_future because in Python >= 3.5, [async was made keyword](https://www.python.org/dev/peps/pep-0492/#backwards-compatibility)

Signed-off-by: Dan Yeaw <dan@yeaw.me>