### PR TITLE
Fixes #40 - Corrects Python version specifier.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires='>3.5'
+    python_requires='>=3.5'
 )


### PR DESCRIPTION
Modifies `python_requires` version specifier to match version compatibility metadata.

This only affects users with a recent version of pip - pip < 9 doesn't enforce `python_version` specifiers.