### PR TITLE
Add an upper pin to pygobject.

### DIFF
--- a/changes/185.bugfix.rst
+++ b/changes/185.bugfix.rst
@@ -1,0 +1,1 @@
+PyGObject support was pinned to an upper version less than 3.50.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 dependencies = [
     # Dependencies required at runtime are set as ranges to ensure maximum
     # compatibility with the end-user's development environment.
-    "pygobject >= 3.14.0",
+    "pygobject >= 3.14.0, < 3.50.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
PyGObject 3.50.0 has been released, and which introduces some minor incompatibilities with GBulb in the process. As a workaround, this PR imposes an upper version pin of `< 3.50.0`.

Refs #185.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
